### PR TITLE
Update udev rules and default nmea gps device.

### DIFF
--- a/src/communication_pkg/scripts/resources/udevRules/50-igvc-sensors.rules
+++ b/src/communication_pkg/scripts/resources/udevRules/50-igvc-sensors.rules
@@ -1,5 +1,5 @@
 # IGVC BU-353 GPS
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="067b", ATTRS{idProduct}=="2303", ATTRS{product}=="USB-Serial Controller" \
+SUBSYSTEM=="tty", ATTRS{idVendor}=="067b", ATTRS{idProduct}=="2303", ATTRS{product}=="USB-Serial Controller" \
     MODE:="0666", \
     ENV{ID_MM_DEVICE_IGNORE}="1", \
     SYMLINK+="igvc_gps"
@@ -16,6 +16,11 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="1415", ATTRS{idProduct}=="2000", ATTRS{prod
     ENV{ID_MM_DEVICE_IGNORE}="1", \
     SYMLINK+="igvc_eye_camera"
 
+# IGVC NEO-M8P RTK GPS
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1546", ATTRS{idProduct}=="01a8", ATTRS{product}=="u-blox GNSS receiver" \
+    MODE:="0666", \
+    ENV{ID_MM_DEVICE_IGNORE}="1", \
+    SYMLINK+="igvc_rtk_gps"
 # If you share your linux system with other users, or just don't like the
 # idea of write permission for everybody, you can replace MODE:="0666" with
 # OWNER:="yourusername" to create the device owned by you, or with

--- a/src/gps_pkg/nmea_navsat_driver/scripts/nmea_serial_driver
+++ b/src/gps_pkg/nmea_navsat_driver/scripts/nmea_serial_driver
@@ -41,7 +41,7 @@ import libnmea_navsat_driver.driver
 if __name__ == '__main__':
     rospy.init_node('nmea_serial_driver')
 
-    serial_port = rospy.get_param('~port','/dev/ttyUSB0')
+    serial_port = rospy.get_param('~port','/dev/igvc_gps')
     serial_baud = rospy.get_param('~baud',4800)
     frame_id = libnmea_navsat_driver.driver.RosNMEADriver.get_frame_id()
 


### PR DESCRIPTION
udev rule:
    Add rule for RTK GPS.
nmea_serial_driver:
    Change default GPS device to match udev link name.

Close #4 