### PR TITLE
Add CATKIN_IGNORE for mapviz to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ cfg/cpp
 
 #devel files
 devel/*
+
+# Package specific ignores
+src/tools_pkg/visualization_pkg/mapviz/CATKIN_IGNORE


### PR DESCRIPTION
Mapviz will not compile on Jetson, so ignore it. 
Jetson will have the CATKIN_IGNORE file locally.

Thanks @Kwuerch !

Closes #33 