### PR TITLE
Fix BoardComms USB and update udev rules

### DIFF
--- a/src/communication_pkg/boardcomms/scripts/CommsHandler.py
+++ b/src/communication_pkg/boardcomms/scripts/CommsHandler.py
@@ -39,7 +39,7 @@ class CommsHandler(object):
             self.interface = EthClient(ip, port, 5)
         else:
             rospy.loginfo("Connecting to serial %s baud:%d"%(port, baud))
-            self.iterface = serial.Serial(port, baud, timeout=1)
+            self.interface = serial.Serial(port, baud, timeout=1)
 
         self.mqueue = deque()
         self.seq_num = 0

--- a/src/resource_pkg/udevRules/49-igvc-firmware.rules
+++ b/src/resource_pkg/udevRules/49-igvc-firmware.rules
@@ -5,7 +5,7 @@ SUBSYSTEM=="tty", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", ATTRS{produ
     SYMLINK+="igvc_comm"
 
 # IGVC USB Bootloader
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", ATTRS{product}=="IGVC USB Bootloader" \
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", ATTRS{product}=="IGVC USB Bootloader" \
     MODE:="0666", \
     ENV{ID_MM_DEVICE_IGNORE}="1", \
     SYMLINK+="igvc_boot"

--- a/src/resource_pkg/udevRules/49-igvc-firmware.rules
+++ b/src/resource_pkg/udevRules/49-igvc-firmware.rules
@@ -1,5 +1,5 @@
 # IGVC USB ComPort
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", ATTRS{product}=="IGVC USB ComPort" \
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", ATTRS{product}=="IGVC USB ComPort" \
     MODE:="0666", \
     ENV{ID_MM_DEVICE_IGNORE}="1", \
     SYMLINK+="igvc_comm"


### PR DESCRIPTION
BoardComms USB works again.
Udev rules updated for tty subsystem instead of usb. This should be verified on another computer at some point.

Closes #35 