### PR TITLE
[I46] Change neo_m8p.yaml config

### DIFF
--- a/src/sensors_pkg/gnss_pkg/ublox/ublox_gps/config/neo_m8p.yaml
+++ b/src/sensors_pkg/gnss_pkg/ublox/ublox_gps/config/neo_m8p.yaml
@@ -28,7 +28,7 @@ uart1:
 gnss:
   glonass: true             # Supported by C94-M8P
   beidou: false             # Supported by C94-M8P
-  qzss: false               # Supported by C94-M8P
+  qzss: true                # Supported by C94-M8P
 
 dgnss_mode: 3               # Fixed mode
 


### PR DESCRIPTION
Quick fix to stop the cold resetting of NEO-M8P.

-Change qzss configuration parameter from 'false' to 'true'. This allows
the node to recognize default configuration.

Closes #46 